### PR TITLE
fix: handle missing choices in OpenAI stream

### DIFF
--- a/src/libs/model-runtime/utils/streams/openai/openai.test.ts
+++ b/src/libs/model-runtime/utils/streams/openai/openai.test.ts
@@ -243,6 +243,40 @@ describe('OpenAIStream', () => {
     ]);
   });
 
+  it('should emit usage when choices are missing but usage exists', async () => {
+    const mockOpenAIStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          id: '99',
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            total_tokens: 3,
+            prompt_cache_miss_tokens: 1,
+          },
+        });
+
+        controller.close();
+      },
+    });
+
+    const protocolStream = OpenAIStream(mockOpenAIStream);
+
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+
+    // @ts-ignore
+    for await (const chunk of protocolStream) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+
+    expect(chunks).toEqual([
+      'id: 99\n',
+      'event: usage\n',
+      `data: {"inputCacheMissTokens":1,"inputTextTokens":1,"outputTextTokens":2,"totalInputTokens":1,"totalOutputTokens":2,"totalTokens":3}\n\n`,
+    ]);
+  });
+
   it('should handle error when there is not correct error', async () => {
     const mockOpenAIStream = new ReadableStream({
       start(controller) {
@@ -280,7 +314,7 @@ describe('OpenAIStream', () => {
         `data: "Hello"\n`,
         'id: 1',
         'event: error',
-        `data: {"body":{"message":"chat response streaming chunk parse error, please contact your API Provider to fix it.","context":{"error":{"message":"Cannot read properties of undefined (reading '0')","name":"TypeError"},"chunk":{"id":"1"}}},"type":"StreamChunkError"}\n`,
+        `data: {"body":{"message":"chat response streaming chunk parse error, please contact your API Provider to fix it.","context":{"error":{"message":"Missing choices in OpenAI stream chunk","name":"Error"},"chunk":{"id":"1"}}},"type":"StreamChunkError"}\n`,
       ].map((i) => `${i}\n`),
     );
   });

--- a/src/libs/model-runtime/utils/streams/openai/openai.ts
+++ b/src/libs/model-runtime/utils/streams/openai/openai.ts
@@ -42,15 +42,16 @@ const transformOpenAIStream = (
 
   try {
     // maybe need another structure to add support for multiple choices
-    const item = chunk.choices[0];
-    if (!item) {
+    if (!Array.isArray(chunk.choices) || chunk.choices.length === 0) {
       if (chunk.usage) {
         const usage = chunk.usage;
         return { data: convertUsage(usage, provider), id: chunk.id, type: 'usage' };
       }
 
-      return { data: chunk, id: chunk.id, type: 'data' };
+      throw new Error('Missing choices in OpenAI stream chunk');
     }
+
+    const item = chunk.choices[0];
 
     if (item && typeof item.delta?.tool_calls === 'object' && item.delta.tool_calls?.length > 0) {
       // tools calling


### PR DESCRIPTION
## Summary
- validate `choices` structure before parsing OpenAI stream chunks
- test usage emission and error message when `choices` are absent

## Testing
- `pnpm test src/libs/model-runtime/utils/streams/openai/openai.test.ts` *(fails: connect ENETUNREACH / Database not initialized)*
- `pnpm lint:ts src/libs/model-runtime/utils/streams/openai/openai.ts src/libs/model-runtime/utils/streams/openai/openai.test.ts` *(fails: Database not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_689690c0962883258050ffab117eb90f